### PR TITLE
fix: correct occured to occurred typo in gui.go

### DIFF
--- a/gui.go
+++ b/gui.go
@@ -61,7 +61,7 @@ func windowUpdateFunction(w *nucular.Window) {
 		deflickeringError := runDeflickering()
 		if deflickeringError != nil {
 			clear()
-			fmt.Println("An error occured:")
+			fmt.Println("An error occurred:")
 			fmt.Println(deflickeringError)
 		}
 	}


### PR DESCRIPTION
Correct spelling typo in user-facing error message shown when deflickering fails.

fmt.Println("An error occured:") → fmt.Println("An error occurred:")

Minimal change, surgical fix following Simplicity First principle.