### PR TITLE
fix: correct 'occured' to 'occurred' typo in error message

### DIFF
--- a/main.go
+++ b/main.go
@@ -25,7 +25,7 @@ func main() {
 		deflickeringError := runDeflickering()
 		if deflickeringError != nil {
 			clear()
-			fmt.Println("An error occured:")
+			fmt.Println("An error occurred:")
 			fmt.Println(deflickeringError)
 			os.Exit(1)
 		}


### PR DESCRIPTION
## Summary
Corrected 'occured' to 'occurred' typo in user-facing error message in `main.go` line 28.

## Changes
- `fmt.Println("An error occured:")` → `fmt.Println("An error occurred:")`

## Compliance
- [x] Single commit (e811156)
- [x] 1 file changed, 1 insertion, 1 deletion
- [x] User-facing error message (stdout print)
- [x] Fixes typo in Go error handling

Submitted by Jah-yee